### PR TITLE
Add schedule to ndb postgres module

### DIFF
--- a/modules/ndb-pg-db/main.tf
+++ b/modules/ndb-pg-db/main.tf
@@ -90,6 +90,35 @@ resource "nutanix_ndb_database" "postgres-db" {
     description = "Time machine for terraform managed pg database"
     slaid       = data.nutanix_ndb_sla.sla.id
 
-    schedule {}
+    schedule {
+      snapshottimeofday{
+                hours= 1
+                minutes= 0
+                seconds= 0
+            }
+            continuousschedule{
+                enabled=true
+                logbackupinterval= 30
+                snapshotsperday=1
+            }
+            weeklyschedule{
+                enabled=true
+                dayofweek= "MONDAY"
+            }
+            monthlyschedule{
+                enabled = true
+                dayofmonth= 1
+            }
+            quartelyschedule{
+                enabled=true
+                startmonth="JANUARY"
+                dayofmonth= 1
+            }
+            yearlyschedule{
+                enabled= false
+                dayofmonth= 1
+                month="DECEMBER"
+            }
+    }
   }
 }


### PR DESCRIPTION
This fixes postgres databases created with the ndb-pg-db module not showing their size and not having functioning Time Machines.

Nutanix Terraform provider states that schedule settings are optional, but not setting them seems to cause issues. The module now sets schedule settings for the Time Machine when creating a new postgres DB.