### PR TITLE
Use EFI and scram-sha-256

### DIFF
--- a/modules/ndb-pg-db/main.tf
+++ b/modules/ndb-pg-db/main.tf
@@ -64,6 +64,8 @@ resource "nutanix_ndb_database" "postgres-db" {
 
     database_names = var.database_name
 
+    auth_method = "scram-sha-256"
+
     post_create_script = "sudo touch /.autorelabel"
   }
 

--- a/modules/postgres-profile-vm/main.tf
+++ b/modules/postgres-profile-vm/main.tf
@@ -29,6 +29,7 @@ resource "nutanix_virtual_machine" "postgres_profile_vm" {
   memory_size_mib      = var.memory
   num_sockets          = var.cpu
   num_vcpus_per_socket = var.cpu_cores
+  boot_type            = "UEFI"
 
   disk_list {
     data_source_reference = {


### PR DESCRIPTION
- Set boot type to UEFI
- Set postgres encyption type to avoid using the default of md5 which causes FIPS enabled hosts to fail opening DB connections