### PR TITLE
Add support for NDB HApostgres profile creation and DB provisioning

### DIFF
--- a/modules/ndb-pg-db-ha/README.md
+++ b/modules/ndb-pg-db-ha/README.md
@@ -1,0 +1,53 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_nutanix"></a> [nutanix](#requirement\_nutanix) | >= 1.9.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_nutanix"></a> [nutanix](#provider\_nutanix) | >= 1.9.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [nutanix_ndb_database.postgres-db](https://registry.terraform.io/providers/nutanix/nutanix/latest/docs/resources/ndb_database) | resource |
+| [random_string.uid](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
+| [nutanix_ndb_cluster.cluster](https://registry.terraform.io/providers/nutanix/nutanix/latest/docs/data-sources/ndb_cluster) | data source |
+| [nutanix_ndb_profile.compute_profile](https://registry.terraform.io/providers/nutanix/nutanix/latest/docs/data-sources/ndb_profile) | data source |
+| [nutanix_ndb_profile.db_param_profile](https://registry.terraform.io/providers/nutanix/nutanix/latest/docs/data-sources/ndb_profile) | data source |
+| [nutanix_ndb_profile.network_profile](https://registry.terraform.io/providers/nutanix/nutanix/latest/docs/data-sources/ndb_profile) | data source |
+| [nutanix_ndb_profile.software_profile](https://registry.terraform.io/providers/nutanix/nutanix/latest/docs/data-sources/ndb_profile) | data source |
+| [nutanix_ndb_sla.sla](https://registry.terraform.io/providers/nutanix/nutanix/latest/docs/data-sources/ndb_sla) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_compute_profile_name"></a> [compute\_profile\_name](#input\_compute\_profile\_name) | The name of the compute profile in NDB to use for the DB. Ex: large-compute | `string` | n/a | yes |
+| <a name="input_database_name"></a> [database\_name](#input\_database\_name) | Name to use for postgres DB created during provisioning. | `string` | `"postgres"` | no |
+| <a name="input_database_size"></a> [database\_size](#input\_database\_size) | The size in GiB to give for postgres data. | `string` | n/a | yes |
+| <a name="input_db_param_profile_name"></a> [db\_param\_profile\_name](#input\_db\_param\_profile\_name) | The name of the database parameter profile in NDB to use for the DB. Ex: DEFAULT\_POSTGRES\_PARAMS | `string` | n/a | yes |
+| <a name="input_db_password"></a> [db\_password](#input\_db\_password) | The password to set for the postgres DB postgres user. | `string` | n/a | yes |
+| <a name="input_instance_name"></a> [instance\_name](#input\_instance\_name) | Name used as a prefix for the postgres instance, VM, and time machine names. | `string` | n/a | yes |
+| <a name="input_network_profile_name"></a> [network\_profile\_name](#input\_network\_profile\_name) | The name of the network profile in NDB to use for the DB. Ex: DEFAULT\_OOB\_POSTGRESQL\_NETWORK | `string` | n/a | yes |
+| <a name="input_nutanix_cluster_name"></a> [nutanix\_cluster\_name](#input\_nutanix\_cluster\_name) | The name of the Nutanix cluster to deploy to. | `string` | n/a | yes |
+| <a name="input_sla_name"></a> [sla\_name](#input\_sla\_name) | The name of the time machine SLA in NDB to use for the DB. Ex: DEFAULT\_OOB\_BRASS\_SLA | `string` | n/a | yes |
+| <a name="input_software_profile_name"></a> [software\_profile\_name](#input\_software\_profile\_name) | The name of the software profile in NDB to use for the DB. Uses the latest published version of the profile. Ex: 'postgres-14.9' | `string` | n/a | yes |
+| <a name="input_ssh_authorized_key"></a> [ssh\_authorized\_key](#input\_ssh\_authorized\_key) | An SSH public key to allow for login to the era user on postgres databases | `string` | n/a | yes |
+| <a name="input_unique_suffix"></a> [unique\_suffix](#input\_unique\_suffix) | Whether to add a unique suffix to the instance\_name for the VM, postgres instance, and time machine names. Not added to the database\_name. | `bool` | `true` | no |
+| <a name="input_vm_password"></a> [vm\_password](#input\_vm\_password) | The password to set for the VM era user. | `string` | `null` | no |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/modules/ndb-pg-db-ha/main.tf
+++ b/modules/ndb-pg-db-ha/main.tf
@@ -1,0 +1,193 @@
+locals {
+  uname = var.unique_suffix ? lower("${var.instance_name}-${random_string.uid.result}") : lower(var.instance_name)
+}
+
+resource "random_string" "uid" {
+  length  = 3
+  special = false
+  lower   = true
+  upper   = false
+  numeric = true
+}
+
+data "nutanix_ndb_profile" "software_profile" {
+  profile_type = "Software"
+  profile_name = var.software_profile_name
+}
+
+data "nutanix_ndb_profile" "compute_profile" {
+  profile_type = "Compute"
+  profile_name = var.compute_profile_name
+}
+
+data "nutanix_ndb_profile" "network_profile" {
+  profile_type = "Network"
+  profile_name = var.network_profile_name
+}
+
+data "nutanix_ndb_profile" "db_param_profile" {
+  profile_type = "Database_Parameter"
+  profile_name = var.db_param_profile_name
+}
+
+data "nutanix_ndb_cluster" "cluster" {
+  cluster_name = var.nutanix_cluster_name
+}
+
+data "nutanix_ndb_sla" "sla" {
+  sla_name = var.sla_name
+}
+
+resource "nutanix_ndb_database" "postgres-db" {
+
+  // name of database type
+  databasetype = "postgres_database"
+
+  // required name of db instance
+  name        = local.uname
+  description = "Postgres DB provisioned via Terraform"
+
+  // adding the profiles details
+  softwareprofileid        = data.nutanix_ndb_profile.software_profile.id
+  softwareprofileversionid = data.nutanix_ndb_profile.software_profile.latest_version_id
+  computeprofileid         = data.nutanix_ndb_profile.compute_profile.id
+  networkprofileid         = data.nutanix_ndb_profile.network_profile.id
+  dbparameterprofileid     = data.nutanix_ndb_profile.db_param_profile.id
+
+  clustered = true
+  
+  nodecount = var.node_count + 1
+
+  // postgreSQL Info
+  postgresql_info {
+    listener_port = "5432"
+
+    database_size = var.database_size
+
+    db_password = var.db_password
+
+    database_names = var.database_name
+
+    auth_method = "scram-sha-256"
+
+    post_create_script = "sudo touch /.autorelabel"
+
+    # cluster_database = true
+
+    ha_instance {
+      cluster_name = "${local.uname}-cluster"
+      patroni_cluster_name = "${local.uname}-patroni"
+      proxy_read_port = "5001"
+      proxy_write_port = "5000"
+      deploy_haproxy = var.deploy_haproxy
+      # failover_mode = "Automatic"
+    }
+  }
+
+  // era cluster id
+  nxclusterid = data.nutanix_ndb_cluster.cluster.id
+
+  // ssh-key
+  sshpublickey = var.ssh_authorized_key
+
+  // node for single instance
+
+  dynamic "nodes" {
+    for_each = var.deploy_haproxy ? [1] : []
+
+    content {
+        properties {
+        name =  "node_type"
+        value = "haproxy"
+      }
+      // name of dbserver vm 
+      vmname = "${local.uname}-haproxy-vm"
+
+      // network profile id
+      networkprofileid = data.nutanix_ndb_profile.network_profile.id
+    }
+  }
+
+  nodes {
+    properties {
+      name= "role"
+      value=  "Primary"
+    }
+    properties {
+      name= "failover_mode"
+      value=  "Automatic"
+    }
+    properties {
+      name= "node_type"
+      value=  "database"
+    }
+
+    vmname = "${local.uname}-vm-0"
+    networkprofileid = data.nutanix_ndb_profile.network_profile.id
+  }
+
+
+  dynamic "nodes" {
+    for_each = range(var.node_count - 1)
+
+    content {
+      properties {
+        name= "role"
+        value=  "Secondary"
+      }
+      properties {
+        name= "failover_mode"
+        value=  "Automatic"
+      }
+      properties {
+        name= "node_type"
+        value=  "database"
+      }
+      // name of dbserver vm 
+      vmname = "${local.uname}-vm-${nodes.key + 1}"
+
+      // network profile id
+      networkprofileid = data.nutanix_ndb_profile.network_profile.id
+    }
+  }
+
+  vm_password = var.vm_password
+
+  // time machine info 
+  timemachineinfo {
+    name        = "${local.uname}-TM"
+    description = "Time machine for terraform managed pg database"
+    slaid       = data.nutanix_ndb_sla.sla.id
+
+    schedule {
+      snapshottimeofday {
+        hours   = 1
+        minutes = 0
+        seconds = 0
+      }
+      continuousschedule {
+        enabled           = true
+        logbackupinterval = 30
+        snapshotsperday   = 1
+      }
+      weeklyschedule {
+        enabled   = true
+        dayofweek = "MONDAY"
+      }
+      monthlyschedule {
+        enabled    = true
+        dayofmonth = 1
+      }
+      quartelyschedule {
+        enabled    = true
+        startmonth = "JANUARY"
+        dayofmonth = 1
+      }
+      yearlyschedule {
+        enabled    = false
+        dayofmonth = 1
+        month      = "DECEMBER"
+      }
+    }
+  }
+}

--- a/modules/ndb-pg-db-ha/variables.tf
+++ b/modules/ndb-pg-db-ha/variables.tf
@@ -1,0 +1,83 @@
+#NDB settings
+
+variable "software_profile_name" {
+  description = "The name of the software profile in NDB to use for the DB. Uses the latest published version of the profile. Ex: 'postgres-14.9'"
+  type        = string
+}
+
+variable "compute_profile_name" {
+  description = "The name of the compute profile in NDB to use for the DB. Ex: large-compute"
+  type        = string
+}
+
+variable "network_profile_name" {
+  description = "The name of the network profile in NDB to use for the DB. Ex: DEFAULT_OOB_POSTGRESQL_NETWORK"
+  type        = string
+}
+
+variable "db_param_profile_name" {
+  description = "The name of the database parameter profile in NDB to use for the DB. Ex: DEFAULT_POSTGRES_PARAMS"
+  type        = string
+}
+
+variable "sla_name" {
+  description = "The name of the time machine SLA in NDB to use for the DB. Ex: DEFAULT_OOB_BRASS_SLA"
+  type        = string
+}
+
+#Database settings
+
+variable "database_name" {
+  description = "Name to use for postgres DB created during provisioning."
+  type        = string
+  default     = "postgres"
+}
+
+variable "db_password" {
+  description = "The password to set for the postgres DB postgres user."
+  type        = string
+}
+
+variable "database_size" {
+  description = "The size in GiB to give for postgres data."
+  type        = string
+}
+
+# VM settings
+
+variable "instance_name" {
+  description = "Name used as a prefix for the postgres instance, VM, and time machine names."
+  type        = string
+}
+
+variable "node_count" {
+  description = "How many postgres nodes to create in an HA cluster"
+  type        = number
+}
+
+variable "deploy_haproxy" {
+  description = "Should HA proxy be deployed?"
+  type        = bool
+}
+
+variable "unique_suffix" {
+  description = "Whether to add a unique suffix to the instance_name for the VM, postgres instance, and time machine names. Not added to the database_name."
+  type        = bool
+  default     = true
+}
+
+variable "nutanix_cluster_name" {
+  description = "The name of the Nutanix cluster to deploy to."
+  type        = string
+}
+
+variable "ssh_authorized_key" {
+  description = "An SSH public key to allow for login to the era user on postgres databases"
+  type        = string
+}
+
+variable "vm_password" {
+  description = "The password to set for the VM era user."
+  type        = string
+  default     = null
+}

--- a/modules/ndb-pg-db-ha/versions.tf
+++ b/modules/ndb-pg-db-ha/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    nutanix = {
+      source  = "nutanix/nutanix"
+      version = ">= 1.9.0"
+    }
+  }
+}
+

--- a/modules/postgres-profile-vm/cloud-config.tpl.yaml
+++ b/modules/postgres-profile-vm/cloud-config.tpl.yaml
@@ -31,23 +31,29 @@ runcmd:
     # Mount postgres default data location to second drive. This is required by NDB
     sudo mount /dev/pg_data_vg/pg_data_lv /var/lib/pgsql/
     echo '/dev/pg_data_vg/pg_data_lv  /pgsql/postgres/data  ext4  defaults 0 0' | sudo  tee -a /etc/fstab
-    sudo mkdir -p /var/lib/pgsql/${postgres_version}/data/
-    # Copy postgres default service to the location that NDB writes the era_postgres service. This ensures it is overwritten by NDB VMs which avoids multiple PG services running at once
-    sudo cp /usr/lib/systemd/system/postgresql-${postgres_version}.service /etc/systemd/system/era_postgres.service
+    sudo mkdir -p /var/lib/pgsql/data/
     # Ensure postgres user owns data dir
     sudo chown -R postgres:postgres /var/lib/pgsql/
     # Init and start PG service
-    sudo /usr/pgsql-${postgres_version}/bin/postgresql-${postgres_version}-setup initdb
+    su postgres -c "/usr/local/pgsql/bin/initdb -D /var/lib/pgsql/data"
     sudo systemctl enable era_postgres
     # Update pg_hba.conf to match what NDB uses
-    sed -E -i 's/local(\s+)all(\s+)all(\s+)peer/local\1all\2all\3trust/' /var/lib/pgsql/14/data/pg_hba.conf
-    sed -E -i 's/local(\s+)replication(\s+)all(\s+)peer/local\1replication\2all\3scram-sha-256/' /var/lib/pgsql/14/data/pg_hba.conf
-    echo "host all all 0.0.0.0/0 scram-sha-256" | sudo tee -a /var/lib/pgsql/14/data/pg_hba.conf
-    echo "listen_addresses = '*'" | sudo tee -a /var/lib/pgsql/14/data/postgresql.conf
+    sed -E -i 's/local(\s+)all(\s+)all(\s+)peer/local\1all\2all\3trust/' /var/lib/pgsql/data/pg_hba.conf
+    sed -E -i 's/local(\s+)replication(\s+)all(\s+)peer/local\1replication\2all\3scram-sha-256/' /var/lib/pgsql/data/pg_hba.conf
+    echo "host all all 0.0.0.0/0 scram-sha-256" | tee -a /var/lib/pgsql/data/pg_hba.conf
+    echo "listen_addresses = '*'" | tee -a /var/lib/pgsql/data/postgresql.conf
     sudo systemctl start era_postgres
-    psql -U postgres -c "ALTER USER postgres PASSWORD '${pg_password}'"
+    /usr/local/pgsql/bin/psql -U postgres -c "ALTER USER postgres PASSWORD '${pg_password}'"
     sudo firewall-offline-cmd --zone=public --add-service=postgresql
+    sudo firewall-offline-cmd --zone=public --add-port=2379/tcp
+    sudo firewall-offline-cmd --zone=public --add-port=2380/tcp
+    sudo firewall-offline-cmd --zone=public --add-protocol=vrrp
+    sudo firewall-offline-cmd --zone=public --add-rich-rule='rule family="ipv4" source address="224.0.0.18" accept'
     sudo firewall-offline-cmd --zone=public --permanent --add-service=postgresql
+    sudo firewall-offline-cmd --zone=public --permanent --add-port=2379/tcp
+    sudo firewall-offline-cmd --zone=public --permanent --add-port=2380/tcp
+    sudo firewall-offline-cmd --zone=public --permanent --add-protocol=vrrp
+    sudo firewall-offline-cmd --zone=public --permanent --add-rich-rule='rule family="ipv4" source address="224.0.0.18" accept'
     sudo systemctl restart firewalld
     # If an NTP server address is passed in then overwrite chrony.conf with settings needed for using custom NTP server
     if [ "${ntp_server}" ]; then


### PR DESCRIPTION
- Updates profile vm module to support changes to postgres profile image for HA postgres
- Adds new HA postgres module for provisioning HA postgres DBs with Nutanix NDB

Currently there is a bug causing NDB (testing with version 2.6) to fail provisioning DBs using a profile if the password set for the new DB doesn't match the password that the profile was created with. The current workaround is to provision with the same password and then connect to the VM(s) and update the password to the desired value. Then update the password for the VM in NDB so that it can still connect to the DBs. This only affects the VM NDB user password, not the postgres password for DB connections.